### PR TITLE
Corrected webtorrent package name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For scraping, the script uses simple gnu utils like sed, awk, paste, cut.
 
 ## Requirements
 
-* [webtorrent](https://webtorrent.io/) - A tool to stream torrent. `sudo npm install webtorrent -g`
+* [webtorrent](https://webtorrent.io/) - A tool to stream torrent. `sudo npm install webtorrent-cli -g`
 
 ## Installation
 


### PR DESCRIPTION
Installing webtorrent using "npm install webtorrent -g" will only install a package that can be accessed from inside a js file using require or import.
To run it from the cli, you need to install webtorrent-cli.