### PR TITLE
Changing shebang from sh to bash

### DIFF
--- a/notflix
+++ b/notflix
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Dependencies - webtorrent, mpv
 
@@ -67,7 +67,7 @@ fullURL="${baseurl}${url}/"
 
 # Requesting page for magnet link
 curl -s $fullURL > $cachedir/tmp.html
-magnet=$(grep -Po "magnet:\?xt=urn:btih:[a-zA-Z0-9]*" $cachedir/tmp.html | head -n 1) 
+magnet=$(grep -Po "magnet:\?xt=urn:btih:[a-zA-Z0-9]*" $cachedir/tmp.html | head -n 1)
 
 webtorrent "$magnet" --mpv
 


### PR DESCRIPTION
I am changing the shebang from #!/bin/sh to #!/bin/bash because the script will break when people who symlink other shells (like dash) to /bin/sh because this program uses here-strings which is not POSIX and a bash feature.