### PR TITLE
add dmenu as requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For scraping, the script uses simple gnu utils like sed, awk, paste, cut.
 ## Requirements
 
 * [webtorrent](https://webtorrent.io/) - A tool to stream torrent. `npm install webtorrent-cli -g`
-
+* [dmenu](https://tools.suckless.org/dmenu/) - A tool for convenient menus. 
 ## Installation
 
 ### cURL


### PR DESCRIPTION
```dmenu``` is an undocumented dependency. Most likely, users of this script already have ```dmenu```  installed, but nevertheless.