### PR TITLE
Accept space-separated command line argument

### DIFF
--- a/notflix
+++ b/notflix
@@ -8,7 +8,7 @@ menu="dmenu -i -l 25"
 baseurl="https://1337x.wtf"
 cachedir="$HOME/.cache/notflix"
 
-if [ -z $1 ]; then
+if [ -z "$1" ]; then
   query=$(dmenu -p "Search Torrent: " <&-)
 else
   query=$1


### PR DESCRIPTION
Without quoting the variable, each word in a space separated string would act as a separate parameter and so line 11 would raise an error.