### PR TITLE
Fully grep instead of head.

### DIFF
--- a/notflix
+++ b/notflix
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 query=$(printf '%s' "$*" | tr ' ' '+' )
-movie=$(curl -s https://1337x.wtf/search/$query/1/ | grep -Eo "torrent\/[0-9]{7}\/[a-zA-Z0-9?%-]*/" | head -n 1)
-magnet=$(curl -s https://1337x.wtf/$movie | grep -Po "magnet:\?xt=urn:btih:[a-zA-Z0-9]*" | head -n 1)
+movie=$(curl -s https://1337x.wtf/search/$query/1/ | grep -m 1 -Eo "torrent\/[0-9]{7}\/[a-zA-Z0-9?%-]*/")
+magnet=$(curl -s https://1337x.wtf/$movie | grep -m 1 -Po "magnet:\?xt=urn:btih:[a-zA-Z0-9]*")
 peerflix -k $magnet


### PR DESCRIPTION
'grep' is already in use. Just blowed off the 'head' part and made it use 'grep' only.