### PR TITLE
Accept any number of digits after torrent/

### DIFF
--- a/notflix
+++ b/notflix
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 query=$(printf '%s' "$*" | tr ' ' '+' )
-movie=$(curl -s https://1337x.wtf/search/$query/1/ | grep -Eo "torrent\/[0-9]{7}\/[a-zA-Z0-9?%-]*/" | head -n 1)
+movie=$(curl -s https://1337x.wtf/search/$query/1/ | grep -Eo "torrent\/[0-9]*\/[a-zA-Z0-9?%-]*/" | head -n 1)
 magnet=$(curl -s https://1337x.wtf/$movie | grep -Po "magnet:\?xt=urn:btih:[a-zA-Z0-9]*" | head -n 1)
 peerflix -k $magnet


### PR DESCRIPTION
There aren't always 7 digits after `/torrent/`.
For example, I found this link that has 6 digits and it made notflix get stuck: https://1337x.wtf/torrent/278525/Ra-One-2011-Hindi-Movie-DVDRIP-XVID-MP3-ESUBS-Team-MJY/