### PR TITLE
Fixed Curl not redirecting on domains

### DIFF
--- a/notflix
+++ b/notflix
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 query=$(printf '%s' "$*" | tr ' ' '+' )
-movie=$(curl -s https://1337x.wtf/search/$query/1/ | grep -Eo "torrent\/[0-9]{7}\/[a-zA-Z0-9?%-]*/" | head -n 1)
-magnet=$(curl -s https://1337x.wtf/$movie | grep -Po "magnet:\?xt=urn:btih:[a-zA-Z0-9]*" | head -n 1)
+movie=$(curl -s -L https://1337x.wtf/search/$query/1/ | grep -Eo "torrent\/[0-9]{7}\/[a-zA-Z0-9?%-]*/" | head -n 1)
+magnet=$(curl -s -L https://1337x.wtf/$movie | grep -Po "magnet:\?xt=urn:btih:[a-zA-Z0-9]*" | head -n 1)
 peerflix -l -k $magnet


### PR DESCRIPTION
Fixed Curl not redirecting on domains that have been moved permanently and shows 301