### PR TITLE
Change the grep to allow for 6-digit (or less!) torrent links.

### DIFF
--- a/notflix
+++ b/notflix
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 query=$(printf '%s' "$*" | tr ' ' '+' )
-movie=$(curl -s https://1337x.to/search/$query/1/ | grep -Eo "torrent\/[0-9]{7}\/[a-zA-Z0-9?%-]*/" | head -n 1)
+movie=$(curl -s https://1337x.to/search/$query/1/ | grep -Eo "torrent\/[0-9]+\/[a-zA-Z0-9?%-]*/" | head -n 1)
 magnet=$(curl -s https://1337x.to/$movie | grep -Po "magnet:\?xt=urn:btih:[a-zA-Z0-9]*" | head -n 1)
 peerflix -l -k $magnet


### PR DESCRIPTION
Right now the grep command for pulling torrent links from 1337x only allows for torrents that have 7-digit links. It should be:
```
#!/bin/sh

query=$(printf '%s' "$*" | tr ' ' '+' )
movie=$(curl -s https://1337x.to/search/$query/1/ | grep -Eo "torrent\/[0-9]+\/[a-zA-Z0-9?%-]*/" | head -n 1)
magnet=$(curl -s https://1337x.to/$movie | grep -Po "magnet:\?xt=urn:btih:[a-zA-Z0-9]*" | head -n 1)
peerflix -l -k $magnet
```


That way older links will be recognized.